### PR TITLE
fix - OpenStreetMap.org request issue

### DIFF
--- a/creditagricole.py
+++ b/creditagricole.py
@@ -95,7 +95,6 @@ class CreditAgricoleRegion:
         openstreetmap_headers = {'User-Agent': 'credit-agricole-importer'}
         response = requests.get(url, headers=openstreetmap_headers).json()
 
-        response = requests.get(url).json()
         if len(response) > 0 and "lon" in response[0] and "lat" in response[0]:
             self.longitude = str(response[0]['lon'])
             self.latitude = str(response[0]['lat'])

--- a/creditagricole.py
+++ b/creditagricole.py
@@ -92,6 +92,9 @@ class CreditAgricoleRegion:
         # Find the bank region location
         address = "Credit Agricole " + self.name + ", France"
         url = 'https://nominatim.openstreetmap.org/search.php?q=' + urllib.parse.quote(address) + '&format=jsonv2'
+        openstreetmap_headers = {'User-Agent': 'credit-agricole-importer'}
+        response = requests.get(url, headers=openstreetmap_headers).json()
+
         response = requests.get(url).json()
         if len(response) > 0 and "lon" in response[0] and "lat" in response[0]:
             self.longitude = str(response[0]['lon'])


### PR DESCRIPTION
When running the original script error occurs at the openstreepmap request (Python 3.13.0) when obtaining the CA Region location.
The cause was found to be a HTTP 403 Forbidden answer due to not specifying the User-Agent.

Header variable was added to that specific request and added to the get function